### PR TITLE
Add code change for the ARM arch and test for amazonLinux ami

### DIFF
--- a/src/main/java/com/amazon/aocagent/testamis/A1AmazonLinux.java
+++ b/src/main/java/com/amazon/aocagent/testamis/A1AmazonLinux.java
@@ -1,0 +1,20 @@
+package com.amazon.aocagent.testamis;
+
+import com.amazon.aocagent.enums.S3Package;
+
+public class A1AmazonLinux extends LinuxAMI {
+  @Override
+  public String getAMIId() {
+    return "ami-091a6d6d0ed7b35fd";
+  }
+
+  @Override
+  public String getLoginUser() {
+    return "ec2-user";
+  }
+
+  @Override
+  public S3Package getS3Package() {
+    return S3Package.AMAZON_LINUX_ARM64_RPM;
+  }
+}

--- a/src/main/java/com/amazon/aocagent/testbeds/EC2TestBed.java
+++ b/src/main/java/com/amazon/aocagent/testbeds/EC2TestBed.java
@@ -31,7 +31,7 @@ public class EC2TestBed implements TestBed {
     ec2Service = new EC2Service(context.getStack().getTestingRegion());
 
     // launch ec2 instance for testing
-    Instance instance = ec2Service.launchInstance(context.getTestingAMI().getAMIId());
+    Instance instance = ec2Service.launchInstance(context.getTestingAMI());
 
     // init sshHelper
     SSHHelper sshHelper =


### PR DESCRIPTION
Currently the launchInstance method uses the default instance type m1.small for launching the instance the m1 small instance type is not available for the ARM arch so we get error while launch ing the new instance so I have added a code to identify the arm arch and define the instance as medium.

Testing:
Tried running the integration test for the ARM instance and now it can successfully launch the instance.  