### PR TITLE
Add integ test for Suse ami AMD64 and ARM64

### DIFF
--- a/src/main/java/com/amazon/aocagent/testamis/A1Suse.java
+++ b/src/main/java/com/amazon/aocagent/testamis/A1Suse.java
@@ -1,0 +1,16 @@
+package com.amazon.aocagent.testamis;
+
+import com.amazon.aocagent.enums.S3Package;
+
+public class A1Suse extends SuseAMI {
+
+  @Override
+  public String getAMIId() {
+    return "ami-0bfc92b18fd79372c";
+  }
+
+  @Override
+  public S3Package getS3Package() {
+    return S3Package.SUSE_ARM64_RPM;
+  }
+}

--- a/src/main/java/com/amazon/aocagent/testamis/Suse.java
+++ b/src/main/java/com/amazon/aocagent/testamis/Suse.java
@@ -1,0 +1,16 @@
+package com.amazon.aocagent.testamis;
+
+import com.amazon.aocagent.enums.S3Package;
+
+public class Suse extends SuseAMI {
+
+  @Override
+  public String getAMIId() {
+    return "ami-063c2d222d223d0e9";
+  }
+
+  @Override
+  public S3Package getS3Package() {
+    return S3Package.SUSE_AMD64_RPM;
+  }
+}

--- a/src/main/java/com/amazon/aocagent/testamis/SuseAMI.java
+++ b/src/main/java/com/amazon/aocagent/testamis/SuseAMI.java
@@ -1,0 +1,20 @@
+package com.amazon.aocagent.testamis;
+
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class SuseAMI extends LinuxAMI {
+
+  @Override
+  public String getLoginUser() {
+    return "ec2-user";
+  }
+
+  @Override
+  public List<String> getDockerInstallingCommands() {
+    return Arrays.asList(
+        "sudo zypper -n in docker",
+        String.format("sudo usermod -aG docker %s", this.getLoginUser()),
+        "sudo systemctl start docker");
+  }
+}


### PR DESCRIPTION
Goal : to add integ test for the suse AMI for both AMD64 and ARM64

Testing: 
gradle run --args="integ-test -t=EC2Test --package-version=v0.1.10-214340474 --ami=Suse"
`Successfull`

gradle run --args="integ-test -t=EC2Test --package-version=v0.1.10-214340474 --ami=A1Suse"
Failed validation as the docker image is only for ARM64 it should once we replace the image.
