### PR TITLE
Add integ test for Ubuntu and Debian for AMD and ARM

### DIFF
--- a/src/main/java/com/amazon/aocagent/services/EC2Service.java
+++ b/src/main/java/com/amazon/aocagent/services/EC2Service.java
@@ -5,7 +5,6 @@ import com.amazon.aocagent.enums.GenericConstants;
 import com.amazon.aocagent.exception.BaseException;
 import com.amazon.aocagent.exception.ExceptionCode;
 import com.amazon.aocagent.helpers.RetryHelper;
-import com.amazon.aocagent.models.Context;
 import com.amazon.aocagent.testamis.ITestAMI;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
@@ -23,6 +22,7 @@ import com.amazonaws.services.ec2.model.Filter;
 import com.amazonaws.services.ec2.model.IamInstanceProfileSpecification;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceStateName;
+import com.amazonaws.services.ec2.model.InstanceType;
 import com.amazonaws.services.ec2.model.IpPermission;
 import com.amazonaws.services.ec2.model.IpRange;
 import com.amazonaws.services.ec2.model.KeyPairInfo;
@@ -36,7 +36,6 @@ import com.amazonaws.services.ec2.model.TagSpecification;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.FileUtils;
-import com.amazonaws.services.ec2.model.InstanceType;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,13 +47,13 @@ import java.util.concurrent.atomic.AtomicReference;
 /** EC2Service is a wrapper of Amazon EC2 Client. */
 @Log4j2
 public class EC2Service {
-  private AmazonEC2 amazonEC2;
-  private String region;
-  private S3Service s3Service;
   private static final String ERROR_CODE_KEY_PAIR_NOT_FOUND = "InvalidKeyPair.NotFound";
   private static final String ERROR_CODE_KEY_PAIR_ALREADY_EXIST = "InvalidKeyPair.Duplicate";
   private static final String ERROR_CODE_SECURITY_GROUP_ALREADY_EXIST = "InvalidGroup.Duplicate";
   private static final String ERROR_CODE_SECURITY_GROUP_NOT_FOUND = "InvalidGroup.NotFound";
+  private AmazonEC2 amazonEC2;
+  private String region;
+  private S3Service s3Service;
 
   /**
    * Construct ec2 service base on region.
@@ -98,9 +97,10 @@ public class EC2Service {
                 new IamInstanceProfileSpecification()
                     .withName(GenericConstants.IAM_ROLE_NAME.getVal()));
 
-
     if (testAMI.getS3Package().getLocalPackage().getArchitecture() == Architecture.ARM64) {
       runInstancesRequest.setInstanceType(InstanceType.A1Medium);
+    } else {
+      runInstancesRequest.setInstanceType(InstanceType.T2Micro);
     }
 
     RunInstancesResult runInstancesResult = amazonEC2.runInstances(runInstancesRequest);

--- a/src/main/java/com/amazon/aocagent/testamis/A1Debian.java
+++ b/src/main/java/com/amazon/aocagent/testamis/A1Debian.java
@@ -1,0 +1,20 @@
+package com.amazon.aocagent.testamis;
+
+import com.amazon.aocagent.enums.S3Package;
+
+public class A1Debian extends DebianAMI {
+  @Override
+  public String getAMIId() {
+    return "ami-0bb8fb45872332e66";
+  }
+
+  @Override
+  public String getLoginUser() {
+    return "admin";
+  }
+
+  @Override
+  public S3Package getS3Package() {
+    return S3Package.DEBIAN_ARM64_DEB;
+  }
+}

--- a/src/main/java/com/amazon/aocagent/testamis/A1Ubuntu.java
+++ b/src/main/java/com/amazon/aocagent/testamis/A1Ubuntu.java
@@ -1,0 +1,20 @@
+package com.amazon.aocagent.testamis;
+
+import com.amazon.aocagent.enums.S3Package;
+
+public class A1Ubuntu extends DebianAMI {
+  @Override
+  public String getAMIId() {
+    return "ami-0c75fb2e6a6be38f6";
+  }
+
+  @Override
+  public String getLoginUser() {
+    return "ubuntu";
+  }
+
+  @Override
+  public S3Package getS3Package() {
+    return S3Package.DEBIAN_ARM64_DEB;
+  }
+}

--- a/src/main/java/com/amazon/aocagent/testamis/Debian.java
+++ b/src/main/java/com/amazon/aocagent/testamis/Debian.java
@@ -1,0 +1,20 @@
+package com.amazon.aocagent.testamis;
+
+import com.amazon.aocagent.enums.S3Package;
+
+public class Debian extends DebianAMI {
+  @Override
+  public String getAMIId() {
+    return "ami-0bb8fb45872332e66";
+  }
+
+  @Override
+  public String getLoginUser() {
+    return "admin";
+  }
+
+  @Override
+  public S3Package getS3Package() {
+    return S3Package.DEBIAN_AMD64_DEB;
+  }
+}

--- a/src/main/java/com/amazon/aocagent/testamis/DebianAMI.java
+++ b/src/main/java/com/amazon/aocagent/testamis/DebianAMI.java
@@ -28,7 +28,15 @@ public abstract class DebianAMI extends LinuxAMI {
   @Override
   public List<String> getDockerInstallingCommands() {
     return Arrays.asList(
-        "sudo snap install docker"
-    );
+        "sudo apt-get update",
+        "sudo apt install -y apt-transport-https ca-certificates "
+            + "curl software-properties-common gnupg2",
+        "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -",
+        String.format(
+            "sudo add-apt-repository \"deb [arch=%s] https://download.docker.com/linux/ubuntu artful  "
+                + "stable\"",
+            this.getS3Package().getLocalPackage().getArchitecture().toString().toLowerCase()),
+        "sudo apt-get update",
+        "sudo apt-get install -y docker-ce");
   }
 }


### PR DESCRIPTION
Goal: To create an integration test for the Debian and Ubuntu for AMD and ARM

Testing:
gradle run --args="integ-test -t=EC2Test --package-version=v0.1.10-214340474 --ami=Ubuntu"
`Successfull`

gradle run --args="integ-test -t=EC2Test --package-version=v0.1.10-214340474 --ami=Debian"
`Successfull`


  