### PR TITLE
Add a docker image which has support for both aarch

### DIFF
--- a/src/main/java/com/amazon/aocagent/enums/GenericConstants.java
+++ b/src/main/java/com/amazon/aocagent/enums/GenericConstants.java
@@ -39,8 +39,12 @@ public enum GenericConstants {
   // configuration
   EC2_CONFIG_PATH("/tmp/test.yml"),
 
-  // metric emitter
-  METRIC_EMITTER_DOCKER_IMAGE_URL("mxiamxia/aoc-metric-generator"),
+
+  /* metric emitter
+  The code to generate the below docker image has been taken from below repository
+   * https://github.com/mxiamxia/aws-cloudwatch-opentelemetry-sample/tree/master/generator
+   * */
+  METRIC_EMITTER_DOCKER_IMAGE_URL("darwhs/aoc-metric-generator"),
 
   // validator related
   METRIC_NAMESPACE("default"),


### PR DESCRIPTION
Goal: To add a docker image which will work for both the ARM64 as well as AMD64

Test: This has been tested for AmazonLinux, A1Amazon, Suse and A1Suse.

Suse : BUILD SUCCESSFUL 

A1Suse : BUILD SUCCESSFUL

Amazon: BUILD SUCCESSFUL 

A1Amazon : BUILD SUCCESSFUL
